### PR TITLE
[fix] disallow text node children of View

### DIFF
--- a/src/components/View/__tests__/index-test.js
+++ b/src/components/View/__tests__/index-test.js
@@ -13,9 +13,20 @@ describe('components/View', () => {
   });
 
   describe('prop "children"', () => {
-    test('text node throws error', () => {
-      const children = 'hello';
-      const render = () => shallow(<View>{children}</View>);
+    test('text node throws error (single)', () => {
+      const render = () => shallow(<View>'hello'</View>);
+      expect(render).toThrow();
+    });
+
+    test('text node throws error (array)', () => {
+      const render = () =>
+        shallow(
+          <View>
+            <View />
+            'hello'
+            <View />
+          </View>
+        );
       expect(render).toThrow();
     });
 

--- a/src/components/View/index.js
+++ b/src/components/View/index.js
@@ -51,10 +51,9 @@ class View extends Component {
     } = this.props;
 
     if (process.env.NODE_ENV !== 'production') {
-      invariant(
-        typeof this.props.children !== 'string',
-        'A text node cannot be a child of a <View>'
-      );
+      React.Children.toArray(this.props.children).forEach(item => {
+        invariant(typeof item !== 'string', 'A text node cannot be a child of a <View>');
+      });
     }
 
     const { isInAParentText } = this.context;

--- a/src/modules/normalizeNativeEvent/__tests__/index-test.js
+++ b/src/modules/normalizeNativeEvent/__tests__/index-test.js
@@ -2,7 +2,7 @@
 
 import normalizeNativeEvent from '..';
 
-const normalizeEvent = (nativeEvent) => {
+const normalizeEvent = nativeEvent => {
   const result = normalizeNativeEvent(nativeEvent);
   result.timestamp = 1496876171255;
   if (result.changedTouches && result.changedTouches[0]) {
@@ -12,7 +12,7 @@ const normalizeEvent = (nativeEvent) => {
     result.touches[0].timestamp = 1496876171255;
   }
   return result;
-}
+};
 
 describe('modules/normalizeNativeEvent', () => {
   describe('mouse events', () => {


### PR DESCRIPTION
Catch text nodes that are not the only child of View. Fixes a case
missing from 0ad6ab948b4e296a85fa03ca1c837d6d1430e596.

**Before submitting a pull request,** please make sure you have followed the steps the CONTRIBUTING guide.
